### PR TITLE
Automate EXE building for Windows

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,16 @@
+rmdir /q /s import-mailbox-to-gmail
+rmdir /q /s import-mailbox-to-gmail-64
+rmdir /q /s build
+rmdir /q /s dist
+del /q /f import-mailbox-to-gmail-%1-windows.zip
+del /q /f import-mailbox-to-gmail-%1-windows-x64.zip
+
+c:\python27-32\scripts\pyinstaller -F --distpath=import-mailbox-to-gmail import-mailbox-to-gmail.spec
+xcopy LICENSE import-mailbox-to-gmail\
+del import-mailbox-to-gmail\w9xpopen.exe
+"%ProgramFiles(x86)%\7-Zip\7z.exe" a -tzip import-mailbox-to-gmail-%1-windows.zip import-mailbox-to-gmail\ -xr!.svn
+
+c:\python27\scripts\pyinstaller -F --distpath=import-mailbox-to-gmail-64 import-mailbox-to-gmail.spec
+xcopy LICENSE import-mailbox-to-gmail-64\
+xcopy whatsnew.txt import-mailbox-to-gmail-64\
+"%ProgramFiles(x86)%\7-Zip\7z.exe" a -tzip import-mailbox-to-gmail-%1-windows-x64.zip import-mailbox-to-gmail-64\ -xr!.svn

--- a/import-mailbox-to-gmail.py
+++ b/import-mailbox-to-gmail.py
@@ -27,13 +27,12 @@ import mailbox
 import os
 import sys
 
-from apiclient import discovery
-from apiclient.http import set_user_agent
+from googleapiclient import discovery
+from googleapiclient.http import set_user_agent
 import httplib2
-from apiclient.http import MediaIoBaseUpload
+from googleapiclient.http import MediaIoBaseUpload
 from oauth2client.service_account import ServiceAccountCredentials
 import oauth2client.tools
-import OpenSSL  # Required by Google API library, but not checked by it
 
 APPLICATION_NAME = 'import-mailbox-to-gmail'
 APPLICATION_VERSION = '1.3'

--- a/import-mailbox-to-gmail.spec
+++ b/import-mailbox-to-gmail.spec
@@ -1,0 +1,21 @@
+# -*- mode: python -*-
+a = Analysis(['import-mailbox-to-gmail.py'],
+             hiddenimports=[],
+             hookspath=None,
+             runtime_hooks=None)
+for d in a.datas:
+    if 'pyconfig' in d[0]: 
+        a.datas.remove(d)
+        break
+a.datas += [('httplib2/cacerts.txt', 'c:\python27\lib\site-packages\httplib2\cacerts.txt', 'DATA')]
+pyz = PYZ(a.pure)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='import-mailbox-to-gmail.exe',
+          debug=False,
+          strip=None,
+          upx=True,
+          console=True )


### PR DESCRIPTION
This patch automates building 32 and 64 .EXE files for Windows admins saving them from the need to install Python, dependencies, etc. Should satisfy issue #13 
