### PR TITLE
Fix up start parameter not working

### DIFF
--- a/import-mailbox-to-gmail.py
+++ b/import-mailbox-to-gmail.py
@@ -202,7 +202,9 @@ def process_mbox_files(username, service, labels):
         logging.error("Skipping label '%s' because it can't be created")
         continue
       logging.info("Using label name '%s', ID '%s'", labelname, label_id)
-      for index, message in enumerate(mbox, start=args.from_message):
+      for index, message in enumerate(mbox):
+        if index < args.from_message:
+          continue
         logging.info("Processing message %d in label '%s'", index, labelname)
         try:
           if (args.replace_quoted_printable and


### PR DESCRIPTION
Turns out my update didn't work as expected, it was reporting the appropriate index however it will starting from the start of the mbox file. 

This fix ensures it loops through the mbox file until it reaches the start message.