### PR TITLE
Avoid duplicate label creation when importing nested folders

### DIFF
--- a/import-mailbox-to-gmail.py
+++ b/import-mailbox-to-gmail.py
@@ -182,7 +182,8 @@ def process_mbox_files(username, service, labels):
   for root, dirs, files in os.walk(base_path):
     for dir in dirs:
       try:
-        get_label_id_from_name(service, username, labels, dir)
+        labelname = os.path.join(root[len(base_path) + 1:], dir)
+        get_label_id_from_name(service, username, labels, labelname)
       except Exception:
         logging.error("Labels under '%s' may not nest correctly", dir)
     for file in files:


### PR DESCRIPTION
This solves #36 by making the first call to `get_label_id_from_name()` in `process_mbox_files()` more similar to the second. This should not affect flat hierarchies, while avoiding unnecessary label creation for nested hierarchies like those created by macOS Mail.

_You may notice that this is my first pull request ever on GitHub, so feel free to give feedback if I omitted something important (or even unimportant) :)_ 