### PR TITLE
Build a standalone executable via PyInstaller

### DIFF
--- a/build-exe.mac.sh
+++ b/build-exe.mac.sh
@@ -7,9 +7,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 NAME='import-mailbox-to-gmail'
 BUILD_DIR="./build"
 
-# Regenerate with, e.g. $ pwgen 16 1
-SIGNING_KEY='jouNae6aifeideeL'
-
 _uname="$(uname)"
 case "${_uname}" in
     [dD]arwin)
@@ -33,14 +30,13 @@ python2 \
     --specpath "${BUILD_DIR}" \
     --console \
     --osx-bundle-identifier "${NAME}" \
-    --key "${SIGNING_KEY}" \
     --onefile \
-    ./import-mailbox-to-gmail.py
+    import-mailbox-to-gmail.py
 _exit_code="$?"
 
 if [[ "${_exit_code}" -ne 0 ]]; then
     echo "Spec file generation failed" >&2
-    exit 1
+    exit ${_exit_code}
 fi
          
 python2 \
@@ -54,6 +50,6 @@ _exit_code="$?"
 
 if [[ "${_exit_code}" -ne 0 ]]; then
     echo "Pyinstaller invocation failed" >&2
-    exit 1
+    exit ${_exit_code}
 fi
 

--- a/build-exe.mac.sh
+++ b/build-exe.mac.sh
@@ -1,0 +1,59 @@
+#! /bin/bash
+# vi: ts=4 sw=4 et syntax=sh :
+
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+
+
+NAME='import-mailbox-to-gmail'
+BUILD_DIR="./build"
+
+# Regenerate with, e.g. $ pwgen 16 1
+SIGNING_KEY='jouNae6aifeideeL'
+
+_uname="$(uname)"
+case "${_uname}" in
+    [dD]arwin)
+        ;;
+    *)
+        die "OS not supported: ${_uname}"
+        ;;
+esac
+
+TOOL_pyinstaller="$(which pyinstaller 2>/dev/null)"
+TOOL_pyi_makespec="$(which pyi-makespec 2>/dev/null)"
+
+if [[ -z "${TOOL_pyinstaller}" || -z "${TOOL_pyi_makespec}" ]]; then
+    echo "Missing required tool: pyinstaller" >&2
+    exit 1
+fi
+
+python2 \
+    "${TOOL_pyi_makespec}" \
+    --name "${NAME}" \
+    --specpath "${BUILD_DIR}" \
+    --console \
+    --osx-bundle-identifier "${NAME}" \
+    --key "${SIGNING_KEY}" \
+    --onefile \
+    ./import-mailbox-to-gmail.py
+_exit_code="$?"
+
+if [[ "${_exit_code}" -ne 0 ]]; then
+    echo "Spec file generation failed" >&2
+    exit 1
+fi
+         
+python2 \
+    "${TOOL_pyinstaller}" \
+    --noconfirm \
+    --clean \
+    --workpath "${BUILD_DIR}" \
+    --distpath="${BUILD_DIR}/exe/macos" \
+    "${BUILD_DIR}/${NAME}.spec"
+_exit_code="$?"
+
+if [[ "${_exit_code}" -ne 0 ]]; then
+    echo "Pyinstaller invocation failed" >&2
+    exit 1
+fi
+


### PR DESCRIPTION
Build a standalone console executable with PyInstaller.

After some experiment in other project I believe it's easy, until the setup is relatively standard, to re-generate every time the spec file with ``pyi-makespec``.
If in the future the spec file should become more complex, we can switch to a static copy.

Extra requirements:

- Python module [pyinstaller](https://pypi.org/project/PyInstaller/)
- Python module [pycrypto](https://pypi.org/project/pycrypto/), if we want PyInstaller to encrypt the code, otherwise we can simply remove the ``--key`` switch