### PR TITLE
Add requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+google-api-python-client
+PyOpenSSL


### PR DESCRIPTION
This will not replace the documentation where we tell how to install the requirements, but provide a better way to automatic deploy the requirements, with:

    pip2 install --upgrade -r requirements.txt

Possible improvements: add a separata requirements file for the dev environment (popular choice seems to be `requirements-dev.txt`), which at the moment will include only [pyinstaller](https://pypi.org/project/PyInstaller/).

In pull request #39 I mentioned also [pycrypto](https://pypi.org/project/pycrypto/), but this is only if we start signing the code with the ``--key`` switch.