### PR TITLE
Add oauth2client as a requirement for this python script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 google-api-python-client
 PyOpenSSL
+oauth2client


### PR DESCRIPTION
oauth2client is needed as a requirement to run this script.

Without this requirement the following error is thrown

```
ImportError: No module named oauth2client.service_account
```